### PR TITLE
Add category filter to Services

### DIFF
--- a/src/Sola_Web/Controllers/ServicesController.cs
+++ b/src/Sola_Web/Controllers/ServicesController.cs
@@ -15,9 +15,17 @@ namespace Sola_Web.Controllers
             _service = service;
             _categoryService = categoryService;
         }
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int? categoryId)
         {
-            return View(await _service.GetAllServicesAsync());
+            var categories = await _categoryService.GetAllServiceCategoriesAsync();
+            ViewBag.Categories = new SelectList(categories, "Id", "Name", categoryId);
+
+            IEnumerable<Service> services = categoryId.HasValue
+                ? await _service.GetServicesByCategoryAsync(categoryId.Value)
+                : await _service.GetAllServicesAsync();
+
+            ViewBag.SelectedCategoryId = categoryId;
+            return View(services);
         }
 
         [HttpGet(Name = "Create")]

--- a/src/Sola_Web/Views/Services/Index.cshtml
+++ b/src/Sola_Web/Views/Services/Index.cshtml
@@ -11,6 +11,18 @@
     <p>
         <a asp-action="AddService">Create New</a>
     </p>
+    <form asp-action="Index" method="get" class="mb-3">
+        <div class="row g-2">
+            <div class="col-md-4">
+                <select name="categoryId" class="form-select" asp-items="ViewBag.Categories">
+                    <option value="">All Categories</option>
+                </select>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Filter</button>
+            </div>
+        </div>
+    </form>
     <table class="table">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- extend `ServicesController.Index` to accept an optional `categoryId` parameter
- add a category filter dropdown to `Views/Services/Index`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878e29914388322bf9f5da2aec6d8e5