### PR TITLE
Fix AddServiceCategory form action typo

### DIFF
--- a/src/Sola_Web/Views/ServiceCategory/AddServiceCategory.cshtml
+++ b/src/Sola_Web/Views/ServiceCategory/AddServiceCategory.cshtml
@@ -15,7 +15,7 @@
     <hr />
     <div class="row">
         <div class="col-md-4">
-            <form asp-action="AddServiceCategpry">
+            <form asp-action="AddServiceCategory">
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 <div class="form-group">
                     <label asp-for="Name" class="control-label"></label>


### PR DESCRIPTION
## Summary
- fix action attribute in `AddServiceCategory` form

## Testing
- `grep -R "AddServiceCategpry" -n || true`


------
https://chatgpt.com/codex/tasks/task_b_6878ddb527108322ad6d61a541eb3b09