### PR TITLE
Refactor service APIs to use domain models

### DIFF
--- a/src/ApplicationCore/Interfaces/IServices/IServiceService.cs
+++ b/src/ApplicationCore/Interfaces/IServices/IServiceService.cs
@@ -8,8 +8,8 @@ namespace ApplicationCore.Interfaces.IServices
         Task<Service?> GetServiceByIdAsync(int id);
         Task<IEnumerable<Service>> GetServicesByCategoryAsync(int categoryId);
         Task<IEnumerable<Service>> GetActiveServicesAsync();
-        Task<Service> CreateServiceAsync(Sola_Web.ViewModels.ServiceViewModel createService);
-        Task<Service> UpdateServiceAsync(Sola_Web.ViewModels.ServiceViewModel updateService);
+        Task<Service> CreateServiceAsync(Service createService);
+        Task<Service> UpdateServiceAsync(Service updateService);
         Task DeleteServiceAsync(int id);
         Task<bool> ServiceExistsAsync(int id);
     }

--- a/src/Infrastructure/Implementations/Services/ServiceService.cs
+++ b/src/Infrastructure/Implementations/Services/ServiceService.cs
@@ -1,7 +1,6 @@
 using ApplicationCore.Models;
 using ApplicationCore.Interfaces.IRepository;
 using ApplicationCore.Interfaces.IServices;
-using Sola_Web.ViewModels;
 
 namespace Infrastructure.Services
 {
@@ -41,39 +40,28 @@ namespace Infrastructure.Services
             return services;
         }
 
-        public async Task<Service> CreateServiceAsync(ServiceViewModel createServiceVM)
+        public async Task<Service> CreateServiceAsync(Service createService)
         {
-            var service = new Service
-            {
-                Name = createServiceVM.Name,
-                Description = createServiceVM.Description,
-                IconUrl = createServiceVM.IconUrl,
-                IsActive = createServiceVM.IsActive,
-                ServiceCategoryId = createServiceVM.ServiceCategoryId
-            };
-
-            var createdService = await _serviceRepository.AddAsync(service);
-            //return MapToDto(updateService);
+            var createdService = await _serviceRepository.AddAsync(createService);
             return createdService;
         }
 
-        public async Task<Service> UpdateServiceAsync(ServiceViewModel updateServiceVM)
+        public async Task<Service> UpdateServiceAsync(Service updateService)
         {
-            var updateService = await _serviceRepository.GetByIdAsync(updateServiceVM.Id);
-            if (updateService == null)
+            var existingService = await _serviceRepository.GetByIdAsync(updateService.Id);
+            if (existingService == null)
             {
-                throw new KeyNotFoundException($"Service with ID {updateServiceVM.Id} not found.");
+                throw new KeyNotFoundException($"Service with ID {updateService.Id} not found.");
             }
 
-            updateService.Name = updateServiceVM.Name;
-            updateService.Description = updateServiceVM.Description;
-            updateService.IconUrl = updateServiceVM.IconUrl;
-            updateService.IsActive = updateServiceVM.IsActive;
-            updateService.ServiceCategoryId = updateServiceVM.ServiceCategoryId;
+            existingService.Name = updateService.Name;
+            existingService.Description = updateService.Description;
+            existingService.IconUrl = updateService.IconUrl;
+            existingService.IsActive = updateService.IsActive;
+            existingService.ServiceCategoryId = updateService.ServiceCategoryId;
 
-            await _serviceRepository.UpdateAsync(updateService);
-            //return MapToDto(updateService);
-            return updateService;
+            await _serviceRepository.UpdateAsync(existingService);
+            return existingService;
         }
 
         public async Task DeleteServiceAsync(int id)

--- a/src/Sola_Web/Controllers/ServicesController.cs
+++ b/src/Sola_Web/Controllers/ServicesController.cs
@@ -41,15 +41,23 @@ namespace Sola_Web.Controllers
         }
 
         [HttpPost(Name = "Create")]
-        public async Task<IActionResult> AddService([Bind("Name,Description,IsActive,ServiceCategoryId")] Service model, IFormFile? iconFile)
+        public async Task<IActionResult> AddService(ServiceViewModel model)
         {
             if (ModelState.IsValid)
             {
-                if (iconFile != null)
+                if (model.IconImage != null)
                 {
-                    model.IconUrl = await _imageService.UploadAsync(iconFile, "services");
+                    model.IconUrl = await _imageService.UploadAsync(model.IconImage, "services");
                 }
-                await _service.CreateServiceAsync(model);
+                var service = new Service
+                {
+                    Name = model.Name,
+                    Description = model.Description,
+                    IconUrl = model.IconUrl,
+                    IsActive = model.IsActive,
+                    ServiceCategoryId = model.ServiceCategoryId
+                };
+                await _service.CreateServiceAsync(service);
                 return RedirectToAction(nameof(Index));
             }
             var categories = await _categoryService.GetAllServiceCategoriesAsync();
@@ -82,15 +90,24 @@ namespace Sola_Web.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> EditService([Bind("Id,Name,Description,IconUrl,IsActive,ServiceCategoryId")] Service model, IFormFile? iconFile)
+        public async Task<IActionResult> EditService(ServiceViewModel model)
         {
             if (ModelState.IsValid)
             {
-                if (iconFile != null)
+                if (model.IconImage != null)
                 {
-                    model.IconUrl = await _imageService.UploadAsync(iconFile, "services");
+                    model.IconUrl = await _imageService.UploadAsync(model.IconImage, "services");
                 }
-                await _service.UpdateServiceAsync(model);
+                var service = new Service
+                {
+                    Id = model.Id,
+                    Name = model.Name,
+                    Description = model.Description,
+                    IconUrl = model.IconUrl,
+                    IsActive = model.IsActive,
+                    ServiceCategoryId = model.ServiceCategoryId
+                };
+                await _service.UpdateServiceAsync(service);
                 return RedirectToAction(nameof(Index));
             }
             var categories = await _categoryService.GetAllServiceCategoriesAsync();


### PR DESCRIPTION
## Summary
- use domain models in `IServiceService` to keep ApplicationCore decoupled from Web
- adjust `ServiceService` to operate on models
- update `ServicesController` to use `ServiceViewModel` only in the MVC layer and map to models

## Testing
- `dotnet build Sola_Web.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878e7af1a8c8322b39ac962501978c2