### PR TITLE
Add service preview and improve layout links

### DIFF
--- a/src/Sola_Web/Views/Services/AddService.cshtml
+++ b/src/Sola_Web/Views/Services/AddService.cshtml
@@ -1,58 +1,71 @@
-﻿@model Sola_Web.ViewModels.ServiceViewModel
+@model Sola_Web.ViewModels.ServiceViewModel
 
 @{
     ViewData["Title"] = "AddService";
 }
 
-<div class="container my-5">
-    <!--astuce pour eviter les chevauchement-->
-    <div style="height:2rem; width:2rem;"></div>
-    <h1>AddService</h1>
-
-    <h4>Service</h4>
-    <hr />
-    <div class="row">
-        <div class="col-md-4">
-            <form asp-action="AddService" enctype="multipart/form-data">
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <div class="form-group">
-                    <label asp-for="Name" class="control-label"></label>
-                    <input asp-for="Name" class="form-control" />
-                    <span asp-validation-for="Name" class="text-danger"></span>
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #ffffff, #f9f9f9);">
+                <div class="card-body">
+                    <h2 class="card-title text-center mb-4" style="font-weight:600; color:#333;">Ajouter un Service</h2>
+                    <form asp-action="AddService" enctype="multipart/form-data">
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <div class="mb-3">
+                            <label asp-for="Name" class="form-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="Description" class="form-label"></label>
+                            <input asp-for="Description" class="form-control" />
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+                        <div class="mb-3 text-center">
+                            <img id="iconPreview" src="#" alt="Preview" class="img-thumbnail mb-2" style="display:none; max-height:200px;" />
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="IconImage" class="form-label"></label>
+                            <input asp-for="IconImage" type="file" class="form-control" onchange="previewIcon(this)" />
+                            <span asp-validation-for="IconImage" class="text-danger"></span>
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" asp-for="IsActive" />
+                            <label class="form-check-label" asp-for="IsActive"></label>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="ServiceCategoryId" class="form-label"></label>
+                            <select asp-for="ServiceCategoryId" class="form-select" asp-items="ViewBag.ServiceCategories">
+                                <option>--Selectionner une Catégorie--</option>
+                            </select>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary">Create</button>
+                        </div>
+                    </form>
                 </div>
-                <div class="form-group">
-                    <label asp-for="Description" class="control-label"></label>
-                    <input asp-for="Description" class="form-control" />
-                    <span asp-validation-for="Description" class="text-danger"></span>
+                <div class="card-footer text-center">
+                    <a asp-action="Index" class="text-decoration-none" style="color:#555;">Retour</a>
                 </div>
-                <div class="form-group">
-                    <label asp-for="IconImage" class="control-label"></label>
-                    <input asp-for="IconImage" type="file" class="form-control" />
-                    <span asp-validation-for="IconImage" class="text-danger"></span>
-                </div>
-                <div class="form-group form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" asp-for="IsActive" /> @Html.DisplayNameFor(model => model.IsActive)
-                    </label>
-                </div>
-                <div class="form-group">
-                    <label asp-for="ServiceCategoryId" class="control-label"></label>
-                    <select asp-for="ServiceCategoryId" class="form-control" asp-items="ViewBag.ServiceCategories">
-                        <option>--Selectionner une Catégorie--</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <input type="submit" value="Create" class="btn btn-primary" />
-                </div>
-            </form>
+            </div>
         </div>
-    </div>
-
-    <div>
-        <a asp-action="Index">Back to List</a>
     </div>
 </div>
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    <script>
+        function previewIcon(input) {
+            if (input.files && input.files[0]) {
+                var reader = new FileReader();
+                reader.onload = function (e) {
+                    var img = document.getElementById('iconPreview');
+                    img.src = e.target.result;
+                    img.style.display = 'block';
+                };
+                reader.readAsDataURL(input.files[0]);
+            }
+        }
+    </script>
 }

--- a/src/Sola_Web/Views/Services/EditService.cshtml
+++ b/src/Sola_Web/Views/Services/EditService.cshtml
@@ -4,59 +4,57 @@
     ViewData["Title"] = "EditService";
 }
 
-<div class="container my-5">
-    <div style="height:2rem; width:2rem;"></div>
-    <h1>EditService</h1>
-
-    <h4>Service</h4>
-    <hr />
-    <div class="row">
-        <div class="col-md-4">
-            <form asp-action="EditService" enctype="multipart/form-data">
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                <input type="hidden" asp-for="Id" />
-                <div class="form-group">
-                    <label asp-for="Name" class="control-label"></label>
-                    <input asp-for="Name" class="form-control" />
-                    <span asp-validation-for="Name" class="text-danger"></span>
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #ffffff, #f9f9f9);">
+                <div class="card-body">
+                    <h2 class="card-title text-center mb-4" style="font-weight:600; color:#333;">Modifier un Service</h2>
+                    <form asp-action="EditService" enctype="multipart/form-data">
+                        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                        <input type="hidden" asp-for="Id" />
+                        <div class="mb-3">
+                            <label asp-for="Name" class="form-label"></label>
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="Description" class="form-label"></label>
+                            <input asp-for="Description" class="form-control" />
+                            <span asp-validation-for="Description" class="text-danger"></span>
+                        </div>
+                        <input type="hidden" asp-for="IconUrl" />
+                        <div class="mb-3 text-center">
+                            <img id="iconPreview" src="@Model.IconUrl" class="img-thumbnail mb-2" style="max-height:200px;" />
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="IconImage" class="form-label"></label>
+                            <input asp-for="IconImage" type="file" class="form-control" onchange="previewIcon(this)" />
+                            <span asp-validation-for="IconImage" class="text-danger"></span>
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" asp-for="IsActive" />
+                            <label class="form-check-label" asp-for="IsActive"></label>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="ServiceCategoryId" class="form-label"></label>
+                            <select asp-for="ServiceCategoryId" class="form-select" asp-items="ViewBag.ServiceCategories">
+                                <option>--Selectionner une Catégorie--</option>
+                            </select>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
                 </div>
-                <div class="form-group">
-                    <label asp-for="Description" class="control-label"></label>
-                    <input asp-for="Description" class="form-control" />
-                    <span asp-validation-for="Description" class="text-danger"></span>
+                <div class="card-footer text-center">
+                    <a asp-action="Index" class="text-decoration-none" style="color:#555;">Retour</a>
                 </div>
-                <input type="hidden" asp-for="IconUrl" />
-                <div class="form-group">
-                    <img id="iconPreview" src="@Model.IconUrl" class="img-thumbnail" />
-                </div>
-                <div class="form-group">
-                    <label asp-for="IconImage" class="control-label"></label>
-                    <input asp-for="IconImage" type="file" class="form-control" onchange="previewIcon(this)" />
-                    <span asp-validation-for="IconImage" class="text-danger"></span>
-                </div>
-        
-        <div class="form-group form-check">
-            <label class="form-check-label">
-                <input class="form-check-input" asp-for="IsActive" /> @Html.DisplayNameFor(model => model.IsActive)
-            </label>
+            </div>
         </div>
-        <div class="form-group">
-            <label asp-for="ServiceCategoryId" class="control-label"></label>
-            <select asp-for="ServiceCategoryId" class="form-control" asp-items="ViewBag.ServiceCategories">
-                <option>--Selectionner une Catégorie--</option>
-            </select>
-        </div>
-        <div class="form-group">
-            <input type="submit" value="Save" class="btn btn-primary" />
-        </div>
-            </form>
-        </div>
-    </div>
-
-    <div>
-        <a asp-action="Index">Back to List</a>
     </div>
 </div>
+
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
     <script>

--- a/src/Sola_Web/Views/Shared/_Layout.cshtml
+++ b/src/Sola_Web/Views/Shared/_Layout.cshtml
@@ -113,8 +113,9 @@
 
             <div class="nav-links">
                 <a asp-action="Index" asp-controller="Home">Accueil</a>
-                <a href="#services">Services</a>
-               @*  <a href="#products">Produits</a> *@
+                <a asp-action="Index" asp-controller="Services">Services</a>
+                <a asp-action="Index" asp-controller="ServiceCategory">Catégories</a>
+                @*  <a href="#products">Produits</a> *@
                 @* <a href="#about">À propos</a> *@
                 <a asp-action="Index" asp-controller="Contact" class="btn">Contact</a>
                 @* <a href="#order" class="btn">Commander</a> *@
@@ -149,11 +150,12 @@
                 <h3>Liens rapides</h3>
                 <ul>
                     <li><a asp-action="Index" asp-controller="Home">Accueil</a></li>
-                    <li><a href="#services">Services</a></li>
+                    <li><a asp-action="Index" asp-controller="Services">Services</a></li>
+                    <li><a asp-action="Index" asp-controller="ServiceCategory">Catégories</a></li>
                     @* <li><a href="#products">Produits</a></li> *@
                    @*  <li><a href="#about">À propos</a></li> *@
                     @* <li><a href="#order">Commander</a></li> *@
-                    <li><a asp-action="Index" asp-controller="Home">Contact</a></li>
+                    <li><a asp-action="Index" asp-controller="Contact">Contact</a></li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- enhance AddService view with image preview and new card styling
- redesign EditService view to match branding
- add navigation and footer links for Services and Categories

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68797db864388322afcbee7eb5a39f7c