### PR TITLE
Add invoice PDF generation and email

### DIFF
--- a/src/ApplicationCore/Interfaces/IServices/IEmailAttachmentSender.cs
+++ b/src/ApplicationCore/Interfaces/IServices/IEmailAttachmentSender.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace ApplicationCore.Interfaces.IServices
+{
+    public interface IEmailAttachmentSender
+    {
+        Task SendEmailWithAttachmentAsync(string email, string subject, string message, byte[] attachmentData, string attachmentName);
+    }
+}

--- a/src/Sola_Web/Controllers/InvoiceController.cs
+++ b/src/Sola_Web/Controllers/InvoiceController.cs
@@ -1,0 +1,47 @@
+using ApplicationCore.Interfaces.IServices;
+using Microsoft.AspNetCore.Mvc;
+using Sola_Web.Services;
+using Sola_Web.ViewModels;
+
+namespace Sola_Web.Controllers
+{
+    public class InvoiceController : Controller
+    {
+        private readonly IViewRenderService _renderer;
+        private readonly IPdfService _pdfService;
+        private readonly IEmailAttachmentSender _emailSender;
+
+        public InvoiceController(IViewRenderService renderer, IPdfService pdfService, IEmailAttachmentSender emailSender)
+        {
+            _renderer = renderer;
+            _pdfService = pdfService;
+            _emailSender = emailSender;
+        }
+
+        [HttpGet]
+        public IActionResult Create()
+        {
+            var model = new InvoiceViewModel
+            {
+                Items = new List<InvoiceItemViewModel> { new InvoiceItemViewModel() }
+            };
+            return View(model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create(InvoiceViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var html = await _renderer.RenderToStringAsync("Invoice/Invoice", model);
+            var pdfBytes = _pdfService.GeneratePdfFromHtml(html);
+
+            await _emailSender.SendEmailWithAttachmentAsync(model.Email, "Invoice", "Please find attached your invoice.", pdfBytes, "invoice.pdf");
+
+            return File(pdfBytes, "application/pdf", "invoice.pdf");
+        }
+    }
+}

--- a/src/Sola_Web/Program.cs
+++ b/src/Sola_Web/Program.cs
@@ -2,12 +2,15 @@ using ApplicationCore.Interfaces.IRepository;
 using ApplicationCore.Interfaces.IServices;
 using ApplicationCore.Settings;
 using ApplicationCore.Utils;
+using DinkToPdf;
+using DinkToPdf.Contracts;
 using Infrastructure.Data;
 using Infrastructure.Repositories;
 using Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
+using Sola_Web.Services;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -31,8 +34,13 @@ builder.Services.AddScoped<IServiceCategoryRepository, ServiceCategoryRepository
 builder.Services.AddScoped<IServiceService, ServiceService>();
 builder.Services.AddScoped<IServiceCategoryService, ServiceCategoryService>();
 builder.Services.AddScoped<IImageService, ImageService>();
+builder.Services.AddScoped<IViewRenderService, ViewRenderService>();
+builder.Services.AddTransient<IPdfService, PdfService>();
+builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+builder.Services.AddSingleton(typeof(IConverter), new SynchronizedConverter(new PdfTools()));
 
 builder.Services.AddTransient<IEmailSender, EmailSender>();
+builder.Services.AddTransient<IEmailAttachmentSender, EmailSender>();
 builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("EmailSettings"));
 var app = builder.Build();
 

--- a/src/Sola_Web/Services/IPdfService.cs
+++ b/src/Sola_Web/Services/IPdfService.cs
@@ -1,0 +1,7 @@
+namespace Sola_Web.Services
+{
+    public interface IPdfService
+    {
+        byte[] GeneratePdfFromHtml(string html);
+    }
+}

--- a/src/Sola_Web/Services/IViewRenderService.cs
+++ b/src/Sola_Web/Services/IViewRenderService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Sola_Web.Services
+{
+    public interface IViewRenderService
+    {
+        Task<string> RenderToStringAsync(string viewName, object model);
+    }
+}

--- a/src/Sola_Web/Services/PdfService.cs
+++ b/src/Sola_Web/Services/PdfService.cs
@@ -1,0 +1,33 @@
+using DinkToPdf;
+using DinkToPdf.Contracts;
+
+namespace Sola_Web.Services
+{
+    public class PdfService : IPdfService
+    {
+        private readonly IConverter _converter;
+
+        public PdfService(IConverter converter)
+        {
+            _converter = converter;
+        }
+
+        public byte[] GeneratePdfFromHtml(string html)
+        {
+            var doc = new HtmlToPdfDocument
+            {
+                GlobalSettings = {
+                    Orientation = Orientation.Portrait,
+                    PaperSize = PaperKind.A4
+                },
+                Objects = {
+                    new ObjectSettings {
+                        HtmlContent = html,
+                        WebSettings = { DefaultEncoding = "utf-8" }
+                    }
+                }
+            };
+            return _converter.Convert(doc);
+        }
+    }
+}

--- a/src/Sola_Web/Services/ViewRenderService.cs
+++ b/src/Sola_Web/Services/ViewRenderService.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+
+namespace Sola_Web.Services
+{
+    public class ViewRenderService : IViewRenderService
+    {
+        private readonly IRazorViewEngine _viewEngine;
+        private readonly ITempDataProvider _tempDataProvider;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ViewRenderService(IRazorViewEngine viewEngine,
+                                 ITempDataProvider tempDataProvider,
+                                 IServiceProvider serviceProvider,
+                                 IHttpContextAccessor httpContextAccessor)
+        {
+            _viewEngine = viewEngine;
+            _tempDataProvider = tempDataProvider;
+            _serviceProvider = serviceProvider;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<string> RenderToStringAsync(string viewName, object model)
+        {
+            var httpContext = _httpContextAccessor.HttpContext ?? new DefaultHttpContext { RequestServices = _serviceProvider };
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+            await using var sw = new StringWriter();
+            var viewResult = _viewEngine.FindView(actionContext, viewName, false);
+            if (!viewResult.Success)
+            {
+                throw new ArgumentException($"View '{viewName}' not found.");
+            }
+            var viewDictionary = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+            {
+                Model = model
+            };
+            var viewContext = new ViewContext(actionContext, viewResult.View, viewDictionary,
+                new TempDataDictionary(actionContext.HttpContext, _tempDataProvider), sw, new HtmlHelperOptions());
+            await viewResult.View.RenderAsync(viewContext);
+            return sw.ToString();
+        }
+    }
+}

--- a/src/Sola_Web/Sola_Web.csproj
+++ b/src/Sola_Web/Sola_Web.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageReference Include="MimeKit" Version="4.13.0" />
+    <PackageReference Include="DinkToPdf" Version="1.0.8" />
+    <PackageReference Include="DinkToPdf.Contracts" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sola_Web/ViewModels/InvoiceViewModel.cs
+++ b/src/Sola_Web/ViewModels/InvoiceViewModel.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace Sola_Web.ViewModels
+{
+    public class InvoiceItemViewModel
+    {
+        [Required]
+        public string ProductName { get; set; } = string.Empty;
+
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; set; }
+
+        [Range(typeof(decimal), "0", "9999999")]
+        public decimal UnitPrice { get; set; }
+
+        public decimal TotalPrice => Quantity * UnitPrice;
+    }
+
+    public class InvoiceViewModel
+    {
+        public List<InvoiceItemViewModel> Items { get; set; } = new();
+
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        public decimal Total => Items.Sum(i => i.TotalPrice);
+    }
+}

--- a/src/Sola_Web/Views/Invoice/Create.cshtml
+++ b/src/Sola_Web/Views/Invoice/Create.cshtml
@@ -1,0 +1,28 @@
+@model Sola_Web.ViewModels.InvoiceViewModel
+@{
+    ViewData["Title"] = "Create Invoice";
+}
+<h2>Create Invoice</h2>
+<form asp-action="Create" method="post">
+    <div class="mb-3">
+        <label asp-for="Items[0].ProductName" class="form-label">Product</label>
+        <input asp-for="Items[0].ProductName" class="form-control" />
+        <span asp-validation-for="Items[0].ProductName" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Items[0].Quantity" class="form-label">Quantity</label>
+        <input asp-for="Items[0].Quantity" class="form-control" />
+        <span asp-validation-for="Items[0].Quantity" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Items[0].UnitPrice" class="form-label">Unit Price</label>
+        <input asp-for="Items[0].UnitPrice" class="form-control" />
+        <span asp-validation-for="Items[0].UnitPrice" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Email" class="form-label">Email</label>
+        <input asp-for="Email" class="form-control" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Send Invoice</button>
+</form>

--- a/src/Sola_Web/Views/Invoice/Invoice.cshtml
+++ b/src/Sola_Web/Views/Invoice/Invoice.cshtml
@@ -1,0 +1,43 @@
+@model Sola_Web.ViewModels.InvoiceViewModel
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Invoice</title>
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h2>Invoice</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Quantity</th>
+                <th>Unit Price</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.Items)
+        {
+            <tr>
+                <td>@item.ProductName</td>
+                <td>@item.Quantity</td>
+                <td>@item.UnitPrice.ToString("C")</td>
+                <td>@item.TotalPrice.ToString("C")</td>
+            </tr>
+        }
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan="3" style="text-align:right">Grand Total</td>
+                <td>@Model.Total.ToString("C")</td>
+            </tr>
+        </tfoot>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add interface for sending email attachments and extend `EmailSender`
- register converter and services in DI container
- implement invoice PDF generation service
- add Razor renderer service
- implement `InvoiceController` with PDF and email support
- create invoice view model and views
- add PDF library references

## Testing
- `dotnet build src/Sola_Web/Sola_Web.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a1a9b57d48322a9e1be6e34faf811