### PR TITLE
Allow service editing without new icon

### DIFF
--- a/src/Sola_Web/Controllers/ServicesController.cs
+++ b/src/Sola_Web/Controllers/ServicesController.cs
@@ -93,9 +93,10 @@ namespace Sola_Web.Controllers
         [HttpPost]
         public async Task<IActionResult> EditService(ServiceViewModel model)
         {
+            ModelState.Remove(nameof(ServiceViewModel.IconImage));
             if (ModelState.IsValid)
             {
-                if (model.IconImage != null)
+                if (model.IconImage != null && model.IconImage.Length > 0)
                 {
                     model.IconUrl = await _imageService.UploadAsync(model.IconImage, "services");
                 }

--- a/src/Sola_Web/ViewModels/ServiceViewModel.cs
+++ b/src/Sola_Web/ViewModels/ServiceViewModel.cs
@@ -21,7 +21,6 @@ namespace Sola_Web.ViewModels
         [Required]
         public int ServiceCategoryId { get; set; }
 
-        [Required]
         public IFormFile? IconImage { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- make `IconImage` optional on `ServiceViewModel`
- update `EditService` validation to handle optional icon file

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687a1b0447488322bd24855f692e9431