### PR TITLE
Fix wkhtmltopdf runtime error

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="DinkToPdf" Version="1.0.8" />
+    <PackageReference Include="DinkToPdf.Native.Linux64" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sola_Web/Dockerfile
+++ b/src/Sola_Web/Dockerfile
@@ -6,6 +6,9 @@ USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
+RUN apt-get update && \
+    apt-get install -y wkhtmltopdf libgdiplus && \
+    rm -rf /var/lib/apt/lists/*
 
 
 # This stage is used to build the service project


### PR DESCRIPTION
## Summary
- add native wkhtmltopdf binaries for Linux
- install wkhtmltopdf and libgdiplus in Docker container

## Testing
- `dotnet build Sola_Web.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687aa10742d4832285932f5c3c6eb7ec