### PR TITLE
Update DinkToPdf dependency

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="DinkToPdf" Version="1.0.8" />
-    <PackageReference Include="DinkToPdf.Native.Linux64" Version="1.0.8" />
+    <PackageReference Include="DinkToPdf.Native" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sola_Web/Dockerfile
+++ b/src/Sola_Web/Dockerfile
@@ -6,9 +6,6 @@ USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-RUN apt-get update && \
-    apt-get install -y wkhtmltopdf libgdiplus && \
-    rm -rf /var/lib/apt/lists/*
 
 
 # This stage is used to build the service project
@@ -30,5 +27,6 @@ RUN dotnet publish "./Sola_Web.csproj" -c $BUILD_CONFIGURATION -o /app/publish /
 FROM base AS final
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:8080
+ENV LD_LIBRARY_PATH=/app/runtimes/linux-x64/native:$LD_LIBRARY_PATH
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "Sola_Web.dll"]


### PR DESCRIPTION
## Summary
- switch Infrastructure project to use the cross-platform `DinkToPdf.Native` package
- drop installing `wkhtmltopdf` in the web Dockerfile
- set `LD_LIBRARY_PATH` so the bundled native library can be found at runtime

## Testing
- `dotnet restore src/Sola_Web/Sola_Web.csproj` *(fails: command not found)*
- `dotnet run --project src/Sola_Web/Sola_Web.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687aa94905dc8322bfc2ce256f2d5e8d