### PR TITLE
Style CRUD links with bootstrap buttons

### DIFF
--- a/src/Sola_Web/Views/Products/Details.cshtml
+++ b/src/Sola_Web/Views/Products/Details.cshtml
@@ -15,8 +15,8 @@
             <p>@Model.Description</p>
             <p class="fw-bold">Price: @Model.Price.ToString("C")</p>
             <p>Stock: @(Model.Stock > 0 ? "In Stock" : "Out of Stock")</p>
-            <a asp-action="EditProduct" asp-route-id="@Model.Id">Edit</a> |
-            <a asp-action="Index">Back to List</a>
+            <a asp-action="EditProduct" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
+            <a asp-action="Index" class="btn btn-secondary">Back to List</a>
         </div>
     </div>
 </div>

--- a/src/Sola_Web/Views/Products/Index.cshtml
+++ b/src/Sola_Web/Views/Products/Index.cshtml
@@ -7,7 +7,7 @@
 <div class="container my-5">
     <h1>Products</h1>
     <p>
-        <a asp-action="AddProduct">Create New</a>
+        <a asp-action="AddProduct" class="btn btn-primary">Create New</a>
     </p>
     <div class="row g-4">
         @foreach (var item in Model)
@@ -21,9 +21,9 @@
                         <p class="card-text fw-bold">Price: @item.Price.ToString("C")</p>
                         <p class="card-text">Stock: @(item.Stock > 0 ? "In Stock" : "Out of Stock")</p>
                         <div class="mt-auto">
-                            <a asp-action="EditProduct" asp-route-id="@item.Id">Edit</a> |
-                            <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
-                            <a asp-action="DeleteProduct" asp-route-id="@item.Id">Delete</a>
+                            <a asp-action="EditProduct" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Edit</a>
+                            <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
+                            <a asp-action="DeleteProduct" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
                         </div>
                     </div>
                 </div>

--- a/src/Sola_Web/Views/ServiceCategory/Index.cshtml
+++ b/src/Sola_Web/Views/ServiceCategory/Index.cshtml
@@ -9,7 +9,7 @@
     <h1>Index</h1>
 
     <p>
-        <a asp-action="AddServiceCategory">Create New</a>
+        <a asp-action="AddServiceCategory" class="btn btn-primary">Create New</a>
     </p>
     <div class="row g-4">
         @foreach (var item in Model)

--- a/src/Sola_Web/Views/Services/Details.cshtml
+++ b/src/Sola_Web/Views/Services/Details.cshtml
@@ -39,7 +39,7 @@
         </dl>
     </div>
     <div>
-        <a asp-action="EditService" asp-route-id="@Model.Id">Edit</a> |
-        <a asp-action="Index">Back to List</a>
+        <a asp-action="EditService" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
+        <a asp-action="Index" class="btn btn-secondary">Back to List</a>
     </div>
 </div>

--- a/src/Sola_Web/Views/Services/Index.cshtml
+++ b/src/Sola_Web/Views/Services/Index.cshtml
@@ -9,7 +9,7 @@
     <h1>Services</h1>
 
     <p>
-        <a asp-action="AddService">Create New</a>
+        <a asp-action="AddService" class="btn btn-primary">Create New</a>
     </p>
     <form asp-action="Index" method="get" class="mb-3">
         <div class="row g-2">
@@ -33,9 +33,9 @@
                         <h3 class="card-title">@item.Name</h3>
                         <p class="card-text flex-grow-1">@item.Description</p>
                         <div class="mt-3">
-                            <a asp-action="EditService" asp-route-id="@item.Id">Edit</a> |
-                            <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
-                            <a asp-action="DeleteService" asp-route-id="@item.Id">Delete</a>
+                            <a asp-action="EditService" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Edit</a>
+                            <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
+                            <a asp-action="DeleteService" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- style Create buttons in Products/Services/ServiceCategory indexes
- switch Edit/Details/Delete links to bootstrap-styled buttons
- style action links on Product and Service detail pages

## Testing
- `dotnet build Sola_Web.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b0fbd39f883229f8a1d5a72a56eb9