### PR TITLE
Load wkhtmltopdf library before registering converter

### DIFF
--- a/src/Sola_Web/Helpers/NativeLibraryLoader.cs
+++ b/src/Sola_Web/Helpers/NativeLibraryLoader.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Sola_Web.Helpers
+{
+    public static class NativeLibraryLoader
+    {
+        public static IntPtr Load(string path)
+        {
+            return NativeLibrary.Load(path);
+        }
+    }
+}

--- a/src/Sola_Web/Program.cs
+++ b/src/Sola_Web/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.EntityFrameworkCore;
 using Sola_Web.Services;
+using Sola_Web.Helpers;
 using System.Runtime.InteropServices;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -41,6 +42,9 @@ else
 {
     throw new PlatformNotSupportedException("Only Windows and Linux are supported.");
 }
+
+// Load native wkhtmltopdf library before using DinkToPdf
+NativeLibraryLoader.Load(nativeLibPath);
 
 
 // Register repositories

--- a/src/Sola_Web/Sola_Web.csproj
+++ b/src/Sola_Web/Sola_Web.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageReference Include="MimeKit" Version="4.13.0" />
+    <PackageReference Include="DinkToPdf.Native.Win64" Version="1.0.8" />
+    <PackageReference Include="DinkToPdf.Native.Linux64" Version="1.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- ensure wkhtmltopdf native libs are available via `DinkToPdf.Native.*`
- add `NativeLibraryLoader` helper to load the unmanaged library
- invoke loader in `Program.cs` before configuring `SynchronizedConverter`

## Testing
- `dotnet build Sola_Web.sln` *(fails: command not found)*
- `dotnet run --project src/Sola_Web/Sola_Web.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b1bc61a4c8322be8b9c08a398d66d