### PR TITLE
Fix Bootstrap references

### DIFF
--- a/src/Sola_Web/Views/Shared/_Layout.cshtml
+++ b/src/Sola_Web/Views/Shared/_Layout.cshtml
@@ -4,10 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Sola | Solutions Énergétiques Intelligentes </title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6EP7dUF4k5w9L8P1kzKp4YL0R38OkykfIoVyaFqzE+/2"
-          crossorigin="anonymous" />
+    <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/style.css" asp-append-version="true" />
@@ -178,24 +175,6 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/script.js" asp-append-version="true"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-QJHtvGhmr9bInh+JxyYkF0/uENPmrpsbR9yZrOb6F5q3zZ3GTQUJM0yK8sct7P20" crossorigin="anonymous"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>
-
-
-
-
-
-
-    
-    
-
-    
-
-    
-
-    
-
-    
-


### PR DESCRIPTION
## Summary
- use local bootstrap css/js instead of CDN
- remove duplicate script reference

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687bfcdd4eb483229af767f613779a41