### PR TITLE
Remove inline styles from views

### DIFF
--- a/src/Sola_Web/Views/Contact/Index.cshtml
+++ b/src/Sola_Web/Views/Contact/Index.cshtml
@@ -15,51 +15,51 @@
 
     <div class="row justify-content-center">
         <div class="col-md-6">
-            <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #ffffff, #f9f9f9);">
+            <div class="card border-0 shadow-sm gradient-card">
                 <div class="card-body">
-                    <h2 class="card-title text-center mb-4" style="font-weight:600; color:#333;">Nous Contacter</h2>
+                    <h2 class="card-title text-center mb-4 fw-semibold text-dark">Nous Contacter</h2>
                     <form asp-action="Index" enctype="multipart/form-data">
                         <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
                         <div class="mb-3">
                             <label asp-for="Email" class="form-label">Email<span class="text-danger">*</span></label>
-                            <input asp-for="Email" class="form-control" placeholder="Email..." style="border-radius: 0.5rem;">
+                            <input asp-for="Email" class="form-control rounded-input" placeholder="Email...">
                             <span asp-validation-for="Email" class="text-danger"></span>
                         </div>
                         <div class="mb-3">
                             <label asp-for="Name" class="form-label">Name<span class="text-danger">*</span></label>
-                            <input asp-for="Name" class="form-control" placeholder="Name..." style="border-radius: 0.5rem;">
+                            <input asp-for="Name" class="form-control rounded-input" placeholder="Name...">
                             <span asp-validation-for="Name" class="text-danger"></span>
                         </div>
                         <div class="mb-3">
                             <label asp-for="Subject" class="form-label">Objet<span class="text-danger">*</span></label>
-                            <input asp-for="Subject" class="form-control" placeholder="Objet..." style="border-radius: 0.5rem;">
+                            <input asp-for="Subject" class="form-control rounded-input" placeholder="Objet...">
                             <span asp-validation-for="Subject" class="text-danger"></span>
                         </div>
 
                         <div class="mb-3">
                             <label asp-for="Message" class="form-label">Contenu</label>
-                            <textarea asp-for="Message" class="form-control" rows="5" placeholder="Contenu..." style="border-radius: 0.5rem;"></textarea>
+                            <textarea asp-for="Message" class="form-control rounded-input" rows="5" placeholder="Contenu..."></textarea>
                             <span asp-validation-for="Message" class="text-danger"></span>
                         </div>
 
                         @* <div class="mb-3">
                             <label asp-for="ImageFile" class="form-label">Image d'illustration</label>
-                            <input asp-for="ImageFile" type="file" class="form-control" accept="image/*" onchange="previewImage(event)" style="border-radius: 0.5rem;">
+                            <input asp-for="ImageFile" type="file" class="form-control rounded-input" accept="image/*" onchange="previewImage(event)">
                             <span asp-validation-for="ImageFile" class="text-danger"></span>
                             <div id="imagePreview" class="mt-3 text-center">
-                                <img id="previewImg" src="" alt="Prévisualisation" class="img-fluid rounded" style="max-height: 300px; display: none;">
+                                <img id="previewImg" src="" alt="Prévisualisation" class="img-fluid rounded img-preview d-none">
                             </div>
                         </div> *@
 
                         <div class="d-grid">
-                            <button type="submit" class="btn btn-primary btn-lg" style="border-radius: 0.5rem;">
+                            <button type="submit" class="btn btn-primary btn-lg rounded-input">
                                 <i class="fas fa-check-circle me-2"></i> Envoyer
                             </button>
                         </div>
                     </form>
                 </div>
                 <div class="card-footer text-center">
-                    <a asp-action="Index" asp-controller="Home" class="text-decoration-none btn-lg" style="color:#555;">Retour</a>
+                    <a asp-action="Index" asp-controller="Home" class="text-decoration-none btn-lg return-link">Retour</a>
                 </div>
             </div>
         </div>

--- a/src/Sola_Web/Views/Products/Details.cshtml
+++ b/src/Sola_Web/Views/Products/Details.cshtml
@@ -18,7 +18,7 @@
             
             <form asp-controller="Cart" asp-action="AddToCart" method="post" class="mb-3">
                 <input type="hidden" name="productId" value="@Model.Id" />
-                <div class="input-group mb-3" style="max-width: 200px;">
+                <div class="input-group mb-3 max-w-200">
                     <input type="number" name="quantity" class="form-control" value="1" min="1" max="@Model.Stock" />
                     <button type="submit" class="btn btn-success" @(Model.Stock <= 0 ? "disabled" : "")>
                         <i class="bi bi-cart-plus"></i> Add to Cart

--- a/src/Sola_Web/Views/Products/EditProduct.cshtml
+++ b/src/Sola_Web/Views/Products/EditProduct.cshtml
@@ -35,7 +35,7 @@
                         </div>
                         <input type="hidden" asp-for="ImageUrl" />
                         <div class="mb-3 text-center">
-                            <img id="imgPreview" src="@Model.ImageUrl" class="img-thumbnail mb-2" style="max-height:200px;" />
+                            <img id="imgPreview" src="@Model.ImageUrl" class="img-thumbnail mb-2 img-preview" />
                         </div>
                         <div class="mb-3">
                             <label asp-for="ImageFile" class="form-label"></label>

--- a/src/Sola_Web/Views/Services/AddService.cshtml
+++ b/src/Sola_Web/Views/Services/AddService.cshtml
@@ -7,9 +7,9 @@
 <div class="container py-5">
     <div class="row justify-content-center">
         <div class="col-md-6">
-            <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #ffffff, #f9f9f9);">
+            <div class="card border-0 shadow-sm gradient-card">
                 <div class="card-body">
-                    <h2 class="card-title text-center mb-4" style="font-weight:600; color:#333;">Ajouter un Service</h2>
+                    <h2 class="card-title text-center mb-4 fw-semibold text-dark">Ajouter un Service</h2>
                     <form asp-action="AddService" enctype="multipart/form-data">
                         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                         <div class="mb-3">
@@ -23,7 +23,7 @@
                             <span asp-validation-for="Description" class="text-danger"></span>
                         </div>
                         <div class="mb-3 text-center">
-                            <img id="iconPreview" src="#" alt="Preview" class="img-thumbnail mb-2" style="display:none; max-height:200px;" />
+                            <img id="iconPreview" src="#" alt="Preview" class="img-thumbnail mb-2 img-preview d-none" />
                         </div>
                         <div class="mb-3">
                             <label asp-for="IconImage" class="form-label"></label>
@@ -46,7 +46,7 @@
                     </form>
                 </div>
                 <div class="card-footer text-center">
-                    <a asp-action="Index" class="text-decoration-none" style="color:#555;">Retour</a>
+                    <a asp-action="Index" class="text-decoration-none return-link">Retour</a>
                 </div>
             </div>
         </div>

--- a/src/Sola_Web/Views/Services/EditService.cshtml
+++ b/src/Sola_Web/Views/Services/EditService.cshtml
@@ -7,9 +7,9 @@
 <div class="container py-5">
     <div class="row justify-content-center">
         <div class="col-md-6">
-            <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #ffffff, #f9f9f9);">
+            <div class="card border-0 shadow-sm gradient-card">
                 <div class="card-body">
-                    <h2 class="card-title text-center mb-4" style="font-weight:600; color:#333;">Modifier un Service</h2>
+                    <h2 class="card-title text-center mb-4 fw-semibold text-dark">Modifier un Service</h2>
                     <form asp-action="EditService" enctype="multipart/form-data">
                         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                         <input type="hidden" asp-for="Id" />
@@ -25,7 +25,7 @@
                         </div>
                         <input type="hidden" asp-for="IconUrl" />
                         <div class="mb-3 text-center">
-                            <img id="iconPreview" src="@Model.IconUrl" class="img-thumbnail mb-2" style="max-height:200px;" />
+                            <img id="iconPreview" src="@Model.IconUrl" class="img-thumbnail mb-2 img-preview" />
                         </div>
                         <div class="mb-3">
                             <label asp-for="IconImage" class="form-label"></label>
@@ -48,7 +48,7 @@
                     </form>
                 </div>
                 <div class="card-footer text-center">
-                    <a asp-action="Index" class="text-decoration-none" style="color:#555;">Retour</a>
+                    <a asp-action="Index" class="text-decoration-none return-link">Retour</a>
                 </div>
             </div>
         </div>

--- a/src/Sola_Web/wwwroot/css/style.css
+++ b/src/Sola_Web/wwwroot/css/style.css
@@ -412,7 +412,28 @@
             color: #004d40;
         }
 
-        .service-card .card-text {
+.service-card .card-text {
             color: #555;
         }
+
+/* Utility classes for form layouts */
+.rounded-input {
+    border-radius: 0.5rem;
+}
+
+.gradient-card {
+    background: linear-gradient(135deg, #ffffff, #f9f9f9);
+}
+
+.img-preview {
+    max-height: 200px;
+}
+
+.return-link {
+    color: #555;
+}
+
+.max-w-200 {
+    max-width: 200px;
+}
  


### PR DESCRIPTION
## Summary
- centralize shared card and input styles into css classes
- use utility classes instead of inline styles in Contact, Service and Product views

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bfcdbe6e083228fdcc5befb779940