### PR TITLE
Add rounded profile images

### DIFF
--- a/src/Sola_Web/Views/About/Index.cshtml
+++ b/src/Sola_Web/Views/About/Index.cshtml
@@ -16,7 +16,7 @@
         {
             <div class="col-12 col-sm-6 col-md-4">
                 <div class="card h-100 text-center shadow-sm">
-                    <img src="@member.PhotoUrl" class="card-img-top" alt="@member.Name" />
+                    <img src="@member.PhotoUrl" class="card-img-top rounded-circle" alt="@member.Name" />
                     <div class="card-body">
                         <h5 class="card-title">@member.Name</h5>
                         <p class="text-muted">@member.Role</p>


### PR DESCRIPTION
## Summary
- show team photos in circular frames on the About page

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c1c14d6e883229ec3dfae4836db2d