### PR TITLE
Restrict editing buttons to logged-in users

### DIFF
--- a/src/Sola_Web/Views/Products/Details.cshtml
+++ b/src/Sola_Web/Views/Products/Details.cshtml
@@ -26,7 +26,10 @@
                 </div>
             </form>
 
-            <a asp-action="EditProduct" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
+            @if (User.Identity.IsAuthenticated)
+            {
+                <a asp-action="EditProduct" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a>
+            }
             <a asp-action="Index" class="btn btn-secondary">Back to List</a>
         </div>
     </div>

--- a/src/Sola_Web/Views/Products/Index.cshtml
+++ b/src/Sola_Web/Views/Products/Index.cshtml
@@ -7,7 +7,10 @@
 <div class="container my-5">
     <h1>Products</h1>
     <p>
-        <a asp-action="AddProduct" class="btn btn-primary">Create New</a>
+        @if (User.Identity.IsAuthenticated)
+        {
+            <a asp-action="AddProduct" class="btn btn-primary">Create New</a>
+        }
     </p>
     <div class="row g-4">
         @foreach (var item in Model)
@@ -21,9 +24,15 @@
                         <p class="card-text fw-bold">Price: @item.Price.ToString("C")</p>
                         <p class="card-text">Stock: @(item.Stock > 0 ? "In Stock" : "Out of Stock")</p>
                         <div class="mt-auto">
-                            <a asp-action="EditProduct" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Edit</a>
+                            @if (User.Identity.IsAuthenticated)
+                            {
+                                <a asp-action="EditProduct" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Edit</a>
+                            }
                             <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
-                            <a asp-action="DeleteProduct" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+                            @if (User.Identity.IsAuthenticated)
+                            {
+                                <a asp-action="DeleteProduct" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+                            }
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- only show the **Create New** button when a user is signed in
- hide Edit/Delete buttons for products unless authenticated
- hide the Edit button on the product details page unless authenticated

## Testing
- `dotnet test` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_b_687c3754a25c8322876b7b4d3d023812