### PR TITLE
Restore Proforma link in navbar

### DIFF
--- a/src/Sola_Web/Views/Shared/_Layout.cshtml
+++ b/src/Sola_Web/Views/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
                 <a asp-action="Index" asp-controller="Services">Services</a>
                 <a asp-action="Index" asp-controller="ServiceCategory">Catégories</a>
                 <a asp-action="Index" asp-controller="Products">Produits</a>
+                <a asp-action="Create" asp-controller="Invoice">Proforma</a>
                 <a asp-action="Index" asp-controller="About">À propos</a>
                 <a asp-action="Index" asp-controller="Contact">Contact</a>
 


### PR DESCRIPTION
## Summary
- add Proforma invoice link back to main navigation

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687c499e1e108322a157d78d061fb1a6