### PR TITLE
Add add-to-cart button on product cards

### DIFF
--- a/src/Sola_Web/Controllers/CartController.cs
+++ b/src/Sola_Web/Controllers/CartController.cs
@@ -44,7 +44,7 @@ namespace Sola_Web.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> AddToCart(int productId, int quantity = 1)
+        public async Task<IActionResult> AddToCart(int productId, int quantity = 1, string? returnUrl = null)
         {
             var cartId = GetOrCreateCartId();
             try
@@ -55,6 +55,10 @@ namespace Sola_Web.Controllers
             catch (Exception ex)
             {
                 TempData["ErrorMessage"] = ex.Message;
+            }
+            if (!string.IsNullOrEmpty(returnUrl))
+            {
+                return LocalRedirect(returnUrl);
             }
             return RedirectToAction(nameof(Index));
         }

--- a/src/Sola_Web/Views/Products/Index.cshtml
+++ b/src/Sola_Web/Views/Products/Index.cshtml
@@ -6,6 +6,20 @@
 
 <div class="container my-5">
     <h1>Products</h1>
+    @if (TempData["SuccessMessage"] != null)
+    {
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="bi bi-check-circle-fill me-2"></i>@TempData["SuccessMessage"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
+    @if (TempData["ErrorMessage"] != null)
+    {
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>@TempData["ErrorMessage"]
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    }
     <p>
         @if (User.Identity.IsAuthenticated)
         {
@@ -29,6 +43,14 @@
                                 <a asp-action="EditProduct" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Edit</a>
                             }
                             <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-info">Details</a>
+                            <form asp-controller="Cart" asp-action="AddToCart" method="post" class="d-inline">
+                                <input type="hidden" name="productId" value="@item.Id" />
+                                <input type="hidden" name="quantity" value="1" />
+                                <input type="hidden" name="returnUrl" value="@Url.Action("Index", "Products")" />
+                                <button type="submit" class="btn btn-sm btn-success" @(item.Stock <= 0 ? "disabled" : "")>
+                                    <i class="bi bi-cart-plus"></i>
+                                </button>
+                            </form>
                             @if (User.Identity.IsAuthenticated)
                             {
                                 <a asp-action="DeleteProduct" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>


### PR DESCRIPTION
## Summary
- let AddToCart redirect back to the provided returnUrl
- show success/error alerts on the products list
- add an Add To Cart button to every product card

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687c4cdaec608322a544c0a29e03a1f2