### PR TITLE
Fix navbar container wrap

### DIFF
--- a/src/Sola_Web/wwwroot/css/style2.css
+++ b/src/Sola_Web/wwwroot/css/style2.css
@@ -95,6 +95,7 @@ body {
         display: flex;
         justify-content: space-between;
         align-items: center;
+        flex-wrap: nowrap;
     }
 
 .logo {


### PR DESCRIPTION
## Summary
- prevent wrapping of navbar links by adding `flex-wrap: nowrap` to `.navbar .container`

## Testing
- `dotnet test --no-build` *(fails: `command not found`)*
- `apt-get update` *(fails: `403  Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_b_687cf35051e08322b00e644ca22b9de0